### PR TITLE
Experiment compiling without conda gcc (but with libgcc)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,8 @@ install:
       conda update --yes conda
       conda install --yes conda-build jinja2 anaconda-client
 
-      
       conda config --add channels conda-forge
-      
+
 
 script:
   - conda build ./recipe

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ source:
     git_tag: 4.5.5
 
 build:
-    number: 0
+    number: 1
     skip: True  # [win]
 
 requirements:
@@ -19,15 +19,16 @@ requirements:
         - hdf5
         - libnetcdf
         - udunits2
-        - gcc
         - krb5
+        - expat
     run:
         - gsl
         - hdf5
         - libnetcdf
         - udunits2
-        - libgcc
         - krb5
+        - expat
+        - libgcc
 
 test:
     commands:


### PR DESCRIPTION
I want to check what is needed to make `nco` rely only on the system `glibc`.