### PR TITLE
Bump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,10 @@ env:
 
 
 before_install:
+    # Remove homebrew.
     - brew remove --force $(brew list)
+    - brew cleanup -s
+    - rm -rf $(brew --cache)
 
 install:
     - |
@@ -21,8 +24,9 @@ install:
 
       export PATH=/Users/travis/miniconda3/bin:$PATH
 
+      conda config --set show_channel_urls true
       conda update --yes conda
-      conda install --yes conda-build jinja2 anaconda-client
+      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
       conda config --add channels conda-forge
       
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Home: http://nco.sourceforge.net/
 
 Package license: GPL-3.0
 
-Feedstock license: BSD
+Feedstock license: BSD 3-Clause
 
 Summary: Suite of programs for manipulating NetCDF/HDF4 files
 
@@ -69,6 +69,7 @@ Terminology
 
 Current build status
 ====================
+
 Linux: [![Circle CI](https://circleci.com/gh/conda-forge/nco-feedstock.svg?style=svg)](https://circleci.com/gh/conda-forge/nco-feedstock)
 OSX: [![TravisCI](https://travis-ci.org/conda-forge/nco-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/nco-feedstock) 
 Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/nco-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/nco-feedstock/branch/master)

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -20,7 +20,7 @@ channels:
 conda-build:
  root-dir: /feedstock_root/build_artefacts
 
-show_channel_urls: True
+show_channel_urls: true
 
 CONDARC
 )
@@ -29,7 +29,7 @@ cat << EOF | docker run -i \
                         -v ${RECIPE_ROOT}:/recipe_root \
                         -v ${FEEDSTOCK_ROOT}:/feedstock_root \
                         -a stdin -a stdout -a stderr \
-                        pelson/obvious-ci:latest_x64 \
+                        condaforge/linux-anvil \
                         bash || exit $?
 
 export BINSTAR_TOKEN=${BINSTAR_TOKEN}
@@ -40,7 +40,7 @@ echo "$config" > ~/.condarc
 conda clean --lock
 
 conda update --yes --all
-conda install --yes conda-build==1.18.2
+conda install --yes conda-build
 conda info
 
 # Embarking on 1 case(s).

--- a/circle.yml
+++ b/circle.yml
@@ -6,8 +6,7 @@ dependencies:
   # Note, we used to use the naive caching of docker images, but found that it was quicker
   # just to pull each time. #rollondockercaching
   override:
-    - docker pull pelson/obvious-ci:latest_x64
-#    - docker pull pelson/conda32_obvious_ci
+    - docker pull condaforge/linux-anvil
 
 test:
   override:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,15 @@
+{% set version = "4.6.0" %}
 package:
     name: nco
-    version: 4.5.5
+    version: {{ version }}
 
 source:
-    git_url: https://github.com/nco/nco.git
-    git_tag: 4.5.5
+    fn: nco-{{ version }}.tar.gz
+    url: https://github.com/nco/nco/archive/{{ version }}.tar.gz
+    sha256: 2ebeec6456255d363e9f5ef92d45cd809c058495d2c3920de3eacda5098986a9
 
 build:
-    number: 4
+    number: 0
     skip: True  # [win]
 
 requirements:


### PR DESCRIPTION
## What's new?

4.6.0 may be most notable for the debut of ncclimo, a new operator
that generates climatologies from monthly-mean input.
Perhaps it's a tie with ncap2, which has a singularly useful new
feature: variable lists/pointers. ncap2 also has a reduced memory
footprint and a function to simplify adding CF-bounds variables
(Thanks Henry!). As usual, ncremap continues to accrue useful
features, the most notable of which is learning grid information
from the CF "coordinates" attribute, if any.

Work on NCO 4.6.1 has commenced and will better support regridding
variables whose horizontal dimensions are not the
most-rapidly-varying.