### PR TITLE
Pin to libnetcdf 4.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
     sha256: 2ebeec6456255d363e9f5ef92d45cd809c058495d2c3920de3eacda5098986a9
 
 build:
-    number: 0
+    number: 1
     skip: True  # [win]
 
 requirements:
@@ -18,16 +18,16 @@ requirements:
         - antlr
         - curl
         - zlib 1.2*
-        - hdf5 1.8.15*
-        - libnetcdf 4.3*
+        - hdf5 1.8.17*
+        - libnetcdf 4.4*
         - udunits2
         - expat
         - krb5
         - texinfo
     run:
         - gsl
-        - hdf5 1.8.15*
-        - libnetcdf 4.3*
+        - hdf5 1.8.17*
+        - libnetcdf 4.4*
         - udunits2
         - expat
         - libgcc


### PR DESCRIPTION
Needs https://github.com/conda-forge/libnetcdf-feedstock/pull/1.