### PR TITLE
Bump build number and rebuild

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
     sha256: 2ebeec6456255d363e9f5ef92d45cd809c058495d2c3920de3eacda5098986a9
 
 build:
-    number: 2
+    number: 3
     skip: True  # [win]
 
 requirements:


### PR DESCRIPTION
This may have been unintentionally linked to `libgcc` as it was pulled in by `gsl`. Hence, we are trying to do a build number bump to rebuild this on the new `gsl` package that does not pull in `libgcc`.