### PR TITLE
Bump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,10 @@ install:
       bash $MINICONDA_FILE -b
 
       export PATH=/Users/travis/miniconda3/bin:$PATH
-
-      conda config --set show_channel_urls true
-      conda update --yes conda
-      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
       conda config --add channels conda-forge
-      
+      conda config --set show_channel_urls true
+      conda install --yes --quiet conda-forge-build-setup
+      source run_conda_forge_build_setup
 
 script:
   - conda build ./recipe

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ About conda-forge
 
 conda-forge is a community-led conda channel of installable packages.
 In order to provide high-quality builds, the process has been automated into the
-conda-forge GitHub organization. The conda-forge organization contains one repository 
+conda-forge GitHub organization. The conda-forge organization contains one repository
 for each of the installable packages. Such a repository is known as a *feedstock*.
 
 A feedstock is made up of a conda recipe (the instructions on what and how to build
@@ -71,7 +71,7 @@ Current build status
 ====================
 
 Linux: [![Circle CI](https://circleci.com/gh/conda-forge/nco-feedstock.svg?style=svg)](https://circleci.com/gh/conda-forge/nco-feedstock)
-OSX: [![TravisCI](https://travis-ci.org/conda-forge/nco-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/nco-feedstock) 
+OSX: [![TravisCI](https://travis-ci.org/conda-forge/nco-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/nco-feedstock)
 Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/nco-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/nco-feedstock/branch/master)
 
 Current release info
@@ -92,7 +92,7 @@ install and use.
 
 In order to produce a uniquely identifiable distribution:
  * If the version of a package **is not** being increased, please add or increase
-   the [``build/number``](http://conda.pydata.org/docs/building/meta-yaml.html#build-number-and-string). 
+   the [``build/number``](http://conda.pydata.org/docs/building/meta-yaml.html#build-number-and-string).
  * If the version of a package **is** being increased, please remember to return
    the [``build/number``](http://conda.pydata.org/docs/building/meta-yaml.html#build-number-and-string)
    back to 0.

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -14,7 +14,6 @@ config=$(cat <<CONDARC
 
 channels:
  - conda-forge
-
  - defaults # As we need conda-build
 
 conda-build:
@@ -39,9 +38,8 @@ echo "$config" > ~/.condarc
 # A lock sometimes occurs with incomplete builds. The lock file is stored in build_artefacts.
 conda clean --lock
 
-conda update --yes --all
-conda install --yes conda-build
-conda info
+conda install --yes --quiet conda-forge-build-setup
+source run_conda_forge_build_setup
 
 # Embarking on 1 case(s).
     conda build /recipe_root --quiet || exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,10 +3,16 @@
 if [[ $(uname) == Darwin ]]; then
   export LIBRARY_SEARCH_VAR=DYLD_FALLBACK_LIBRARY_PATH
   export LDFLAGS="$LDFLAGS -headerpad_max_install_names"
-  ARGS="--disable-regex --disable-shared --disable-doc"
+  # OS X user won't enjoy OMP due to the bad decision in conda-forge to use clang.
+  export CC=clang
+  export CXX=clang++
+  export MACOSX_DEPLOYMENT_TARGET="10.9"
+  export CXXFLAGS="-stdlib=libc++ $CXXFLAGS"
+  export CXXFLAGS="$CXXFLAGS -stdlib=libc++"
+  ARGS="--disable-openmp --disable-regex --disable-shared --disable-doc"
 elif [[ $(uname) == Linux ]]; then
   export LIBRARY_SEARCH_VAR=LD_LIBRARY_PATH
-  ARGS="--disable-dependency-tracking"
+  ARGS="--enable-openmp --disable-dependency-tracking"
 fi
 
 export HAVE_ANTLR=yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ test:
     commands:
         - ncks --help
         - ncap2 --help
-        - conda inspect linkages -n _test nco  # [linux]
+        - conda inspect linkages -n _test nco  # [not win]
         - conda inspect objects -n _test nco  # [osx]
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.6.0" %}
+{% set version = "4.6.1" %}
 package:
     name: nco
     version: {{ version }}
@@ -6,10 +6,10 @@ package:
 source:
     fn: nco-{{ version }}.tar.gz
     url: https://github.com/nco/nco/archive/{{ version }}.tar.gz
-    sha256: 2ebeec6456255d363e9f5ef92d45cd809c058495d2c3920de3eacda5098986a9
+    sha256: 7433fe5901f48eb5170f24c6d53b484161e1c63884d9350600070573baf8b8b0
 
 build:
-    number: 3
+    number: 0
     skip: True  # [win]
 
 requirements:
@@ -41,6 +41,7 @@ test:
         - ncks --help
         - ncap2 --help
         - conda inspect linkages -n _test nco  # [linux]
+        - conda inspect objects -n _test nco  # [osx]
 
 about:
     home: http://nco.sourceforge.net/


### PR DESCRIPTION
```shell
4.6.1 is mainly a stability release to polish existing features and to add minor new ones.
The main new feature is that ncclimo supports incremental climatologies.
ncatted works much better with special characters in attribute names,
while preserving its ability to handle regular expressions.
ncflint gains a weight-normalization option.
```