### PR TITLE
Update to 4.6.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ before_install:
 
 install:
     - |
-      MINICONDA_URL="http://repo.continuum.io/miniconda"
+      MINICONDA_URL="https://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
       source /Users/travis/miniconda3/bin/activate root

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Package license: GPL-3.0
 
 Feedstock license: BSD 3-Clause
 
-Summary: Suite of programs for manipulating NetCDF/HDF4 files
+Summary: Suite of programs for manipulating NetCDF/HDF4 files.
 
 
 
@@ -31,7 +31,6 @@ It is possible to list all of the versions of `nco` available on your platform w
 ```
 conda search nco --channel conda-forge
 ```
-
 
 
 About conda-forge

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.6.1" %}
+{% set version = "4.6.2" %}
 
 package:
   name: nco
@@ -7,7 +7,7 @@ package:
 source:
   fn: nco-{{ version }}.tar.gz
   url: https://github.com/nco/nco/archive/{{ version }}.tar.gz
-  sha256: 7433fe5901f48eb5170f24c6d53b484161e1c63884d9350600070573baf8b8b0
+  sha256: cec82e35d47a6bbf8ab9301d5ff4cf08051f489b49e8529ebf780380f2c21ed3
 
 build:
   number: 0


### PR DESCRIPTION
```
What's new?

4.6.2 is mainly a stability release to polish existing features and to
add minor new ones. The exception is the new JSON backend.
NCO now prints CDL, "Traditional NCO", XML, and JSON. Babel-icious eh?

We built the JSON backend to help a project (DOE Terraref).
Our first choice was to adopt an off-the-shelf netCDF->JSON tool.
However, no existing solution worked for us.
JSON is a loose syntax, and we made necessary design choices that
suited our application, and left some choices for later.
Are there syntactical variants you want us to add?

Some users of netCDF version 4.4.1 cannot build NCO from scratch
because a bug in the nc-config command kills NCO's 'configure;make'.
Unidata will ship a corrected nc-config in netCDF 4.4.2.
The 4.4.2-development branch already contains the necessary fix.
See (C) in KNOWN PROBLEMS DUE TO BASE LIBRARIES/PROTOCOLS below.

Work on NCO 4.6.3 has commenced. Planned improvements include more
flexibility in handling extensive variables during regridding, CMake
support, and brackets for multi-dimensional array values in JSON.
```