### PR TITLE
Logging

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+meta.yaml text eol=lf
+build.sh text eol=lf
+bld.bat text eol=crlf

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,14 @@ install:
       conda install --yes --quiet conda-forge-build-setup
       source run_conda_forge_build_setup
 
+      # install conda-build 2.x to build with a long prefix
+      conda install --yes --quiet conda-build=2
+      conda info
+
 script:
   - conda build ./recipe
 
   - upload_or_check_non_existence ./recipe conda-forge --channel=main
+
+  # inspect the prefix lengths of the built packages
+  - conda inspect prefix-lengths /Users/travis/miniconda3/conda-bld/osx-64/*.tar.bz2

--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ Summary: Suite of programs for manipulating NetCDF/HDF4 files.
 
 
 
+Current build status
+====================
+
+Linux: [![Circle CI](https://circleci.com/gh/conda-forge/nco-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/nco-feedstock)
+OSX: [![TravisCI](https://travis-ci.org/conda-forge/nco-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/nco-feedstock)
+Windows: ![](https://cdn.rawgit.com/conda-forge/conda-smithy/90845bba35bec53edac7a16638aa4d77217a3713/conda_smithy/static/disabled.svg)
+
+Current release info
+====================
+Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/nco/badges/version.svg)](https://anaconda.org/conda-forge/nco)
+Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/nco/badges/downloads.svg)](https://anaconda.org/conda-forge/nco)
+
 Installing nco
 ==============
 
@@ -66,18 +78,6 @@ Terminology
 
 **conda-forge** - the place where the feedstock and smithy live and work to
                   produce the finished article (built conda distributions)
-
-Current build status
-====================
-
-Linux: [![Circle CI](https://circleci.com/gh/conda-forge/nco-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/nco-feedstock)
-OSX: [![TravisCI](https://travis-ci.org/conda-forge/nco-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/nco-feedstock)
-Windows: ![](https://cdn.rawgit.com/conda-forge/conda-smithy/90845bba35bec53edac7a16638aa4d77217a3713/conda_smithy/static/disabled.svg)
-
-Current release info
-====================
-Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/nco/badges/version.svg)](https://anaconda.org/conda-forge/nco)
-Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/nco/badges/downloads.svg)](https://anaconda.org/conda-forge/nco)
 
 
 Updating nco-feedstock

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -41,7 +41,14 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
+# install conda-build 2.x to build a long prefix
+conda install --yes --quiet conda-build=2
+conda info
+
 # Embarking on 1 case(s).
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+# inspect the prefix lengths of the built packages
+conda inspect prefix-lengths /feedstock_root/build_artefacts/linux-64/*.tar.bz2
 EOF

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.6.2" %}
+{% set version = "4.6.3" %}
 
 package:
   name: nco
@@ -7,7 +7,7 @@ package:
 source:
   fn: nco-{{ version }}.tar.gz
   url: https://github.com/nco/nco/archive/{{ version }}.tar.gz
-  sha256: cec82e35d47a6bbf8ab9301d5ff4cf08051f489b49e8529ebf780380f2c21ed3
+  sha256: 414ccb349ed25cb37b669fb87f9e2e4ca8d58c2f45538feda199bf895b982bf8
 
 build:
   number: 0
@@ -26,7 +26,7 @@ requirements:
     - krb5
     - texinfo
     - bison
-    - flex
+    - flex 2.6.0
     - m4
   run:
     - gsl

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
-fin=$SRC_DIR/data/in.nc
+URL="http://tds.marine.rutgers.edu/thredds/dodsC/roms/espresso/2013_da/his/ESPRESSO_Real-Time_v2_History_Best"
 
-ncks -M http://test.opendap.org:80/opendap/data/ncml/sample_virtual_dataset.ncml
-ncks -F --dimension samples,1 http://test.opendap.org:80/opendap/data/ncml/sample_virtual_dataset.ncml
+ncks -M $URL
+
+fin=$SRC_DIR/data/in.nc
 
 ncks -O --rgr skl=skl_t42.nc --rgr grid=grd_t42.nc --rgr latlon=64,128 --rgr lat_typ=gss --rgr lon_typ=Grn_ctr $fin foo.nc
 ncks -O --rgr grid=grd_2x2.nc --rgr latlon=90,180 --rgr lat_typ=eqa --rgr lon_typ=Grn_wst $fin foo.nc


### PR DESCRIPTION
Closes #24

For some reason `nco` breaks if I use latest `flex` (2.6.2). So I am pinning it to 2.6.0 for now.

Do not merge! Waiting on https://github.com/conda-forge/libnetcdf-feedstock/pull/13.

cc @rsignell-usgs