### PR TITLE
update to 3.6.7

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 source:
   fn: nco-{{ version }}.tar.gz
   url: https://github.com/nco/nco/archive/{{ version }}.tar.gz
-  sha256: 6b9297093e38e29a7b44f263f67aa0e728052d947338bbb1f6fc2a4cc4b910c6
+  sha256: 079d83f800b73d9b12b8de1634a88c2cbe40a639aaf7bc056cd2e836c6047697
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,10 +7,10 @@ package:
 source:
   fn: nco-{{ version }}.tar.gz
   url: https://github.com/nco/nco/archive/{{ version }}.tar.gz
-  sha256: 079d83f800b73d9b12b8de1634a88c2cbe40a639aaf7bc056cd2e836c6047697
+  sha256: 6b9297093e38e29a7b44f263f67aa0e728052d947338bbb1f6fc2a4cc4b910c6
 
 build:
-  number: 1
+  number: 0
   skip: True  # [win]
 
 requirements:


### PR DESCRIPTION
The main new features in 4.6.7 are in the regridder, which introduces a sub-grid regridding option, more automated handling and flexibility with regional grids, and easier flag specification. ncap2 added specialty functions to simplify handling of missing values and in-filling large missing regions with interpolated data. ncatted received an important bugfix for netCDF4 with _FillValue.