### PR TITLE
nco with hdf5 1.8.18

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 5ba930f00a0e9775f85748d145acecfe142f917c180de538b2f8994788446cf8
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win]
 
 requirements:
@@ -18,7 +18,7 @@ requirements:
     - antlr
     - curl >=7.44.0,<8
     - zlib 1.2.11
-    - hdf5 1.10.1
+    - hdf5 1.8.18|1.8.18.*
     - libnetcdf 4.4.*
     - udunits2
     - expat 2.1.*
@@ -29,13 +29,13 @@ requirements:
     - m4
   run:
     - gsl >=2.2,<2.3
-    - hdf5 1.10.1
+    - hdf5 1.8.18|1.8.18.*
     - libnetcdf 4.4.*
     - udunits2
     - expat 2.1.*
     - libgcc
     - esmf
-    - openblas 0.2.19|0.2.19.*
+    - openblas 0.2.20|0.2.20*
 
 test:
   source_files:


### PR DESCRIPTION
@xylar we should revert to `hdf5 1.10` after this is merged, but conda will find this alternative build number and install it when people pin to `hdf5 1.8.18`.