### PR TITLE
Build 4.7.3 with hdf5 1.8.18

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: c79fcfc291976466070e0da04c9ea57924feb7f41e4d89a27f313c465e42b381
 
 build:
-  number: 1
+  number: 200
   skip: True  # [win32 or (win and py<=35)]
   features:
     - vc14  # [win and (py35 or py36)]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: c79fcfc291976466070e0da04c9ea57924feb7f41e4d89a27f313c465e42b381
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win32 or (win and py<=35)]
   features:
     - vc14  # [win and (py35 or py36)]
@@ -26,7 +26,7 @@ requirements:
     - curl >=7.44.0,<8
     - expat 2.2.*
     - gsl >=2.2,<2.3
-    - hdf5 1.10.1
+    - hdf5 1.8.18
     - krb5 1.14.*  # [not win]
     - libnetcdf 4.4.*
     - udunits2
@@ -36,7 +36,7 @@ requirements:
     - curl >=7.44.0,<8
     - expat 2.2.*
     - gsl >=2.2,<2.3
-    - hdf5 1.10.1
+    - hdf5 1.8.18
     - krb5 1.14.*  # [not win]
     - libnetcdf 4.4.*
     - udunits2


### PR DESCRIPTION
This is needed by a metapackage, E3SM-Unified (https://github.com/ACME-Climate/e3sm-unified) that @xylar maintains for the Energy Exascale Earth System Model (E3SM) project. Some of the dependencies (namely UV-CDAT and e3sm_diags) do not yet support HDF5 1.10.1.