### PR TITLE
update netcdf pin

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: c9848ebb5f32ff6d74ba44906b226023fd9073a31bc40e719b1b71728d648632
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win32 or (win and py<=35)]
   features:
     - vc14  # [win and (py35 or py36)]
@@ -28,7 +28,7 @@ requirements:
     - gsl >=2.2,<2.3
     - hdf5 1.10.1
     - krb5 1.14.*  # [not win]
-    - libnetcdf 4.4.*
+    - libnetcdf 4.5.*
     - udunits2
     - zlib 1.2.11
     - vc 14  # [win and (py35 or py36)]
@@ -38,7 +38,7 @@ requirements:
     - gsl >=2.2,<2.3
     - hdf5 1.10.1
     - krb5 1.14.*  # [not win]
-    - libnetcdf 4.4.*
+    - libnetcdf >=4.5
     - udunits2
     - libgcc  # [not win]
     - openblas 0.2.20|0.2.20*  # [not win]


### PR DESCRIPTION
@czender and @xylar  this PR will build with `netcdf-c 4.5.*` but will run with any version above it.
So people will be able install it with `libnetcdf 4.6.1` while we still maintain some backwards compatibility for those who cannot upgrade at the moment. 

Is this OK for your needs @czender? Is there a test of the expected new features/bugfix that we can add here to ensure that the 4.6.1 fixes you need will be in the package?