### PR TITLE
re-add openblas

### DIFF
--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -14,6 +14,8 @@ krb5:
 - '1.14'
 libnetcdf:
 - '4.6'
+openblas:
+- 0.2.20
 pin_run_as_build:
   curl:
     max_pin: x
@@ -27,6 +29,8 @@ pin_run_as_build:
     max_pin: x.x
   libnetcdf:
     max_pin: x.x
+  openblas:
+    max_pin: x.x.x
   zlib:
     max_pin: x.x
 zlib:

--- a/.ci_support/osx_.yaml
+++ b/.ci_support/osx_.yaml
@@ -20,6 +20,8 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
+openblas:
+- 0.2.20
 pin_run_as_build:
   curl:
     max_pin: x
@@ -33,6 +35,8 @@ pin_run_as_build:
     max_pin: x.x
   libnetcdf:
     max_pin: x.x
+  openblas:
+    max_pin: x.x.x
   zlib:
     max_pin: x.x
 zlib:

--- a/.ci_support/win_c_compilervs2015cxx_compilervs2015vc14.yaml
+++ b/.ci_support/win_c_compilervs2015cxx_compilervs2015vc14.yaml
@@ -12,6 +12,8 @@ hdf5:
 - 1.10.2
 libnetcdf:
 - '4.6'
+openblas:
+- 0.2.20
 pin_run_as_build:
   curl:
     max_pin: x
@@ -23,6 +25,8 @@ pin_run_as_build:
     max_pin: x.x.x
   libnetcdf:
     max_pin: x.x
+  openblas:
+    max_pin: x.x.x
   vc:
     max_pin: x
   zlib:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 36f2132482a2eb9910ff9f760f0e61168aee874ad473a187cd8e5f7db2d2e617
 
 build:
-  number: 2
+  number: 3
   skip: True  # [win and vc<14]
 
 requirements:
@@ -29,17 +29,19 @@ requirements:
     - hdf5
     - krb5  # [not win]
     - libnetcdf
+    - openblas
     - udunits2
     - zlib
   run:
     - curl
+    - esmf  # [not win]
     - expat
     - gsl
     - hdf5
     - krb5  # [not win]
     - libnetcdf
+    - openblas
     - udunits2
-    - esmf  # [not win]
 
 test:
   source_files:

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -28,4 +28,4 @@ ncap2 -O -s 'tst[lat,lon]=1.0f' skl_t42.nc dat_t42.nc
 ncremap -a conserve -s grd_t42.nc -g grd_2x2.nc -m map_t42_to_2x2.nc
 ncremap -i dat_t42.nc -m map_t42_to_2x2.nc -o dat_2x2.nc
 ncwa -O dat_2x2.nc dat_avg.nc
-ncks -C -H -v tst dat_avg.nc
+# ncks -C -H -v tst dat_avg.nc

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -26,6 +26,6 @@ ncks -O --rgr grid=grd_2x2.nc \
 ncap2 -O -s 'tst[lat,lon]=1.0f' skl_t42.nc dat_t42.nc
 
 ncremap -a conserve -s grd_t42.nc -g grd_2x2.nc -m map_t42_to_2x2.nc
-ncremap -i dat_t42.nc -m map_t42_to_2x2.nc -o dat_2x2.nc
+# ncremap -i dat_t42.nc -m map_t42_to_2x2.nc -o dat_2x2.nc
 # ncwa -O dat_2x2.nc dat_avg.nc
 # ncks -C -H -v tst dat_avg.nc

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -27,5 +27,5 @@ ncap2 -O -s 'tst[lat,lon]=1.0f' skl_t42.nc dat_t42.nc
 
 ncremap -a conserve -s grd_t42.nc -g grd_2x2.nc -m map_t42_to_2x2.nc
 ncremap -i dat_t42.nc -m map_t42_to_2x2.nc -o dat_2x2.nc
-ncwa -O dat_2x2.nc dat_avg.nc
+# ncwa -O dat_2x2.nc dat_avg.nc
 # ncks -C -H -v tst dat_avg.nc

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -25,7 +25,7 @@ ncks -O --rgr grid=grd_2x2.nc \
 
 ncap2 -O -s 'tst[lat,lon]=1.0f' skl_t42.nc dat_t42.nc
 
-ncremap -a conserve -s grd_t42.nc -g grd_2x2.nc -m map_t42_to_2x2.nc
+# ncremap -a conserve -s grd_t42.nc -g grd_2x2.nc -m map_t42_to_2x2.nc
 # ncremap -i dat_t42.nc -m map_t42_to_2x2.nc -o dat_2x2.nc
 # ncwa -O dat_2x2.nc dat_avg.nc
 # ncks -C -H -v tst dat_avg.nc

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -25,12 +25,7 @@ ncks -O --rgr grid=grd_2x2.nc \
 
 ncap2 -O -s 'tst[lat,lon]=1.0f' skl_t42.nc dat_t42.nc
 
-# This test is hanging on OS X and we don't execute it on Linux due to an odd
-# issue with CircleCI not uploading the binary after the test is executed.
-
-# if [[ $(uname) == Darwin ]]; then
-#   ncremap -a conserve -s grd_t42.nc -g grd_2x2.nc -m map_t42_to_2x2.nc  # FIXME: This call for reason prevent CircleCI from uploading the package!
-#   ncremap -i dat_t42.nc -m map_t42_to_2x2.nc -o dat_2x2.nc
-#   ncwa -O dat_2x2.nc dat_avg.nc
-#   ncks -C -H -v tst dat_avg.nc
-# fi
+ncremap -a conserve -s grd_t42.nc -g grd_2x2.nc -m map_t42_to_2x2.nc
+ncremap -i dat_t42.nc -m map_t42_to_2x2.nc -o dat_2x2.nc
+ncwa -O dat_2x2.nc dat_avg.nc
+ncks -C -H -v tst dat_avg.nc


### PR DESCRIPTION
I was under the illusion that conda-forge's `gsl` would always be selected by conda, but we still need this hack :-(