### PR TITLE
Don't merge! Test to see if the latest NCO fixes tests in CI

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,15 +1,15 @@
-{% set version = "4.7.9" %}
+{% set version = "4.8.0.alpha08" %}
 
 package:
   name: nco
   version: {{ version }}
 
 source:
-  url: https://github.com/nco/nco/archive/{{ version }}.tar.gz
-  sha256: 048f6298bceb40913c3ae433f875dea1e9129b1c86019128e7271d08f274a879
+  git_url: https://github.com/nco/nco.git
+  git_rev: master
 
 build:
-  number: 2
+  number: 0
   skip: True  # [win and vc<14]
 
 requirements:

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -25,11 +25,9 @@ ncks -O --rgr grid=grd_2x2.nc \
 
 ncap2 -O -s 'tst[lat,lon]=1.0f' skl_t42.nc dat_t42.nc
 
-# The next test(s) seems to be hanging in CI (Azure and perhaps others) so they
-# are commented out for now
-# ncremap -a conserve -s grd_t42.nc -g grd_2x2.nc -m map_t42_to_2x2.nc
-# ncremap -i dat_t42.nc -m map_t42_to_2x2.nc -o dat_2x2.nc
-# ncremap -a tempest -s grd_t42.nc -g grd_2x2.nc -m map_tempest_t42_to_2x2.nc
-# ncremap -i dat_t42.nc -m map_tempest_t42_to_2x2.nc -o dat_tempest_2x2.nc
-# ncwa -O dat_2x2.nc dat_avg.nc
-# ncks -C -H -v tst dat_avg.nc
+ncremap --no_stdin -a conserve -s grd_t42.nc -g grd_2x2.nc -m map_t42_to_2x2.nc
+ncremap --no_stdin -i dat_t42.nc -m map_t42_to_2x2.nc -o dat_2x2.nc
+ncremap --no_stdin -a tempest -s grd_t42.nc -g grd_2x2.nc -m map_tempest_t42_to_2x2.nc
+ncremap --no_stdin -i dat_t42.nc -m map_tempest_t42_to_2x2.nc -o dat_tempest_2x2.nc
+ncwa -O dat_2x2.nc dat_avg.nc
+ncks -C -H -v tst dat_avg.nc


### PR DESCRIPTION
The `--no_stdin` option has been added to suppress stdin when needed.

**Note: This PR is just for testing and should not be merged**

Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.