### PR TITLE
Add MPI build matrix

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -10,8 +10,16 @@ jobs:
   strategy:
     maxParallel: 8
     matrix:
-      linux_:
-        CONFIG: linux_
+      linux_mpimpich:
+        CONFIG: linux_mpimpich
+        UPLOAD_PACKAGES: True
+        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+      linux_mpinompi:
+        CONFIG: linux_mpinompi
+        UPLOAD_PACKAGES: True
+        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+      linux_mpiopenmpi:
+        CONFIG: linux_mpiopenmpi
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
   steps:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -10,8 +10,14 @@ jobs:
   strategy:
     maxParallel: 8
     matrix:
-      osx_:
-        CONFIG: osx_
+      osx_mpimpich:
+        CONFIG: osx_mpimpich
+        UPLOAD_PACKAGES: True
+      osx_mpinompi:
+        CONFIG: osx_mpinompi
+        UPLOAD_PACKAGES: True
+      osx_mpiopenmpi:
+        CONFIG: osx_mpiopenmpi
         UPLOAD_PACKAGES: True
 
   steps:

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -10,8 +10,8 @@ jobs:
   strategy:
     maxParallel: 4
     matrix:
-      win_c_compilervs2015cxx_compilervs2015vc14:
-        CONFIG: win_c_compilervs2015cxx_compilervs2015vc14
+      win_c_compilervs2015cxx_compilervs2015mpinompivc14:
+        CONFIG: win_c_compilervs2015cxx_compilervs2015mpinompivc14
         CONDA_BLD_PATH: D:\\bld\\
         UPLOAD_PACKAGES: True
   steps:

--- a/.ci_support/linux_mpimpich.yaml
+++ b/.ci_support/linux_mpimpich.yaml
@@ -1,9 +1,7 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '9'
+- '7'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -11,9 +9,11 @@ channel_targets:
 curl:
 - '7.64'
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '9'
+- '7'
+docker_image:
+- condaforge/linux-anvil-comp7
 expat:
 - '2.2'
 gsl:
@@ -28,10 +28,8 @@ libcblas:
 - 3.8 *netlib
 libnetcdf:
 - 4.7.1
-macos_machine:
-- x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
+mpi:
+- mpich
 pin_run_as_build:
   curl:
     max_pin: x

--- a/.ci_support/linux_mpinompi.yaml
+++ b/.ci_support/linux_mpinompi.yaml
@@ -1,0 +1,45 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '7'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+curl:
+- '7.64'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '7'
+docker_image:
+- condaforge/linux-anvil-comp7
+expat:
+- '2.2'
+gsl:
+- '2.5'
+hdf5:
+- 1.10.5
+krb5:
+- '1.16'
+libblas:
+- 3.8 *netlib
+libcblas:
+- 3.8 *netlib
+libnetcdf:
+- 4.7.1
+mpi:
+- nompi
+pin_run_as_build:
+  curl:
+    max_pin: x
+  expat:
+    max_pin: x.x
+  krb5:
+    max_pin: x.x
+  libnetcdf:
+    max_pin: x.x.x
+  zlib:
+    max_pin: x.x
+zlib:
+- '1.2'

--- a/.ci_support/linux_mpiopenmpi.yaml
+++ b/.ci_support/linux_mpiopenmpi.yaml
@@ -1,0 +1,45 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '7'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+curl:
+- '7.64'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '7'
+docker_image:
+- condaforge/linux-anvil-comp7
+expat:
+- '2.2'
+gsl:
+- '2.5'
+hdf5:
+- 1.10.5
+krb5:
+- '1.16'
+libblas:
+- 3.8 *netlib
+libcblas:
+- 3.8 *netlib
+libnetcdf:
+- 4.7.1
+mpi:
+- openmpi
+pin_run_as_build:
+  curl:
+    max_pin: x
+  expat:
+    max_pin: x.x
+  krb5:
+    max_pin: x.x
+  libnetcdf:
+    max_pin: x.x.x
+  zlib:
+    max_pin: x.x
+zlib:
+- '1.2'

--- a/.ci_support/osx_mpimpich.yaml
+++ b/.ci_support/osx_mpimpich.yaml
@@ -1,7 +1,9 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '7'
+- '9'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -9,11 +11,9 @@ channel_targets:
 curl:
 - '7.64'
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '7'
-docker_image:
-- condaforge/linux-anvil-comp7
+- '9'
 expat:
 - '2.2'
 gsl:
@@ -28,6 +28,12 @@ libcblas:
 - 3.8 *netlib
 libnetcdf:
 - 4.7.1
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+mpi:
+- mpich
 pin_run_as_build:
   curl:
     max_pin: x

--- a/.ci_support/osx_mpinompi.yaml
+++ b/.ci_support/osx_mpinompi.yaml
@@ -1,0 +1,49 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+c_compiler_version:
+- '9'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+curl:
+- '7.64'
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '9'
+expat:
+- '2.2'
+gsl:
+- '2.5'
+hdf5:
+- 1.10.5
+krb5:
+- '1.16'
+libblas:
+- 3.8 *netlib
+libcblas:
+- 3.8 *netlib
+libnetcdf:
+- 4.7.1
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+mpi:
+- nompi
+pin_run_as_build:
+  curl:
+    max_pin: x
+  expat:
+    max_pin: x.x
+  krb5:
+    max_pin: x.x
+  libnetcdf:
+    max_pin: x.x.x
+  zlib:
+    max_pin: x.x
+zlib:
+- '1.2'

--- a/.ci_support/osx_mpiopenmpi.yaml
+++ b/.ci_support/osx_mpiopenmpi.yaml
@@ -1,0 +1,49 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+c_compiler_version:
+- '9'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+curl:
+- '7.64'
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '9'
+expat:
+- '2.2'
+gsl:
+- '2.5'
+hdf5:
+- 1.10.5
+krb5:
+- '1.16'
+libblas:
+- 3.8 *netlib
+libcblas:
+- 3.8 *netlib
+libnetcdf:
+- 4.7.1
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+mpi:
+- openmpi
+pin_run_as_build:
+  curl:
+    max_pin: x
+  expat:
+    max_pin: x.x
+  krb5:
+    max_pin: x.x
+  libnetcdf:
+    max_pin: x.x.x
+  zlib:
+    max_pin: x.x
+zlib:
+- '1.2'

--- a/.ci_support/win_c_compilervs2015cxx_compilervs2015mpinompivc14.yaml
+++ b/.ci_support/win_c_compilervs2015cxx_compilervs2015mpinompivc14.yaml
@@ -18,6 +18,8 @@ libblas:
 - 3.8 *netlib
 libcblas:
 - 3.8 *netlib
+mpi:
+- nompi
 pin_run_as_build:
   curl:
     max_pin: x

--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,7 @@ bld.bat text eol=crlf
 .gitattributes linguist-generated=true
 .gitignore linguist-generated=true
 .travis.yml linguist-generated=true
+.scripts linguist-generated=true
 LICENSE.txt linguist-generated=true
 README.md linguist-generated=true
 azure-pipelines.yml linguist-generated=true

--- a/README.md
+++ b/README.md
@@ -29,24 +29,52 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux</td>
+              <td>linux_mpimpich</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4833&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nco-feedstock?branchName=master&jobName=linux&configuration=linux_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nco-feedstock?branchName=master&jobName=linux&configuration=linux_mpimpich" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx</td>
+              <td>linux_mpinompi</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4833&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nco-feedstock?branchName=master&jobName=osx&configuration=osx_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nco-feedstock?branchName=master&jobName=linux&configuration=linux_mpinompi" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_c_compilervs2015cxx_compilervs2015vc14</td>
+              <td>linux_mpiopenmpi</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4833&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nco-feedstock?branchName=master&jobName=win&configuration=win_c_compilervs2015cxx_compilervs2015vc14" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nco-feedstock?branchName=master&jobName=linux&configuration=linux_mpiopenmpi" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_mpimpich</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4833&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nco-feedstock?branchName=master&jobName=osx&configuration=osx_mpimpich" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_mpinompi</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4833&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nco-feedstock?branchName=master&jobName=osx&configuration=osx_mpinompi" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_mpiopenmpi</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4833&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nco-feedstock?branchName=master&jobName=osx&configuration=osx_mpiopenmpi" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_c_compilervs2015cxx_compilervs2015mpinompivc14</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4833&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nco-feedstock?branchName=master&jobName=win&configuration=win_c_compilervs2015cxx_compilervs2015mpinompivc14" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -15,6 +15,3 @@ export NETCDF_ROOT=$PREFIX
 make -j$CPU_COUNT
 make check
 make install
-
-# We can remove this when we start using the new conda-build.
-find $PREFIX -name '*.la' -delete

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,8 @@
+mpi:
+  - nompi
+  - mpich
+  - openmpi
+
+pin_run_as_build:
+  mpich: x.x
+  openmpi: x.x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,13 @@
 {% set version = "4.8.1" %}
+{% set build = 2 %}
+
+# ensure mpi is defined (needed for conda-smithy recipe-lint)
+{% set mpi = mpi or 'nompi' %}
+
+{% if mpi == 'mpich' %}
+# prioritize mpich variant, which was previously the only option, via build number
+{% set build = build + 100 %}
+{% endif %}
 
 package:
   name: nco
@@ -9,8 +18,21 @@ source:
   sha256: ddae3fed46c266798ed1176d6a70b36376d2d320fa933c716a623172d1e13c68
 
 build:
-  number: 1
-  skip: True  # [win and vc<14]
+  number: {{ build }}
+  skip: True  # [(win and vc<14) or (win and (mpi != 'nompi')) ]
+
+  # add build string so packages can depend on
+  # mpi or nompi variants explicitly:
+  # `nco * mpi_mpich_*` for mpich
+  # `nco * mpi_*` for any mpi
+  # `nco * nompi_*` for no mpi
+
+  {% if mpi != 'nompi' %}
+  {% set mpi_prefix = "mpi_" + mpi %}
+  {% else %}
+  {% set mpi_prefix = "nompi" %}
+  {% endif %}
+  string: "{{ mpi_prefix }}_h{{ PKG_HASH }}_{{ build }}"
 
 requirements:
   build:
@@ -29,22 +51,26 @@ requirements:
     - expat
     - gsl
     - hdf5
+    - hdf5  * {{ mpi_prefix }}_*  # [not win]
     - krb5  # [not win]
     - libnetcdf  # [not win]
+    - libnetcdf  * {{ mpi_prefix }}_*  # [not win]
     - libnetcdf 4.6.1  # [win]
     - udunits2
     - zlib
+    - {{ mpi }}  # [mpi != 'nompi']
   run:
     - curl
-    - esmf  # [not win]
+    - esmf * {{ mpi_prefix }}_*  # [not win]
     - expat
     - gsl
     - hdf5
     - krb5  # [not win]
-    - libnetcdf  # [not win]
+    - libnetcdf * {{ mpi_prefix }}_*  # [not win]
     - libnetcdf 4.6.1  # [win]
     - udunits2
     - tempest-remap  # [not win]
+    - {{ mpi }}  # [mpi != 'nompi']
 
 test:
   source_files:

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -25,8 +25,6 @@ ncks -O --rgr grid=grd_2x2.nc \
 
 ncap2 -O -s 'tst[lat,lon]=1.0f' skl_t42.nc dat_t42.nc
 
-# The next test(s) seems to be hanging in CI (Azure and perhaps others) so they
-# are commented out for now
 ncremap --no_stdin -a conserve -s grd_t42.nc -g grd_2x2.nc -m map_t42_to_2x2.nc
 ncremap --no_stdin -i dat_t42.nc -m map_t42_to_2x2.nc -o dat_2x2.nc
 ncremap --no_stdin -a tempest -s grd_t42.nc -g grd_2x2.nc -m map_tempest_t42_to_2x2.nc


### PR DESCRIPTION
This makes sure the libnetcdf and hdf5 versions match the MPI version and that a version without MPI and one with openmpi are available. Previously, mpich came along with esmf but the libnetcdf and hdf5 versions weren't necessarily the corresponding mpich versions.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
